### PR TITLE
<auto> Placeholder Support for Site URLs

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,7 +23,11 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
-    <release version="1.7.2" date="not released">
+    <release version="1.8.0" date="not released">
+      <action type="add" dev="sseifert"><![CDATA[
+        Placeholder <code>&lt;auto&gt;</code> can be used in the author/publish URL properties in Site Config to enable auto-detection of these URLs based on the requested URL.
+        The placeholder can be combined with a fallback URL - if auto-detection is not possible (because the link is build outside request context) the configured URL is used.
+      ]]></action>
       <action type="update" dev="sseifert">
         Switch to AEM 6.5.7 as minimum version.
       </action>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
   <groupId>io.wcm</groupId>
   <artifactId>io.wcm.handler.url</artifactId>
-  <version>1.7.1-SNAPSHOT</version>
+  <version>1.8.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>URL Handler</name>

--- a/src/main/java/io/wcm/handler/url/SiteConfig.java
+++ b/src/main/java/io/wcm/handler/url/SiteConfig.java
@@ -33,21 +33,21 @@ public @interface SiteConfig {
    * @return Site URL
    */
   @Property(label = "Site URL",
-      description = "Public website URL for non-secure access.")
+      description = "Public website URL for non-secure access. Add placeholder '<auto>' to enable auto-detection from request.")
   String siteUrl();
 
   /**
    * @return Site URL Secure
    */
   @Property(label = "Site URL Secure",
-      description = "Public website URL for secure access.")
+      description = "Public website URL for secure access. Add placeholder '<auto>' to enable auto-detection from request.")
   String siteUrlSecure();
 
   /**
    * @return Author URL
    */
   @Property(label = "Author URL",
-      description = "URL for author instance.")
+      description = "URL for author instance. Add placeholder '<auto>' to enable auto-detection from request.")
   String siteUrlAuthor();
 
 }

--- a/src/main/java/io/wcm/handler/url/impl/UrlHandlerImpl.java
+++ b/src/main/java/io/wcm/handler/url/impl/UrlHandlerImpl.java
@@ -174,7 +174,8 @@ public final class UrlHandlerImpl implements UrlHandler {
   @SuppressWarnings("null")
   private String getLinkUrlPrefix(UrlMode urlMode, Page targetPage) {
     UrlMode mode = ObjectUtils.defaultIfNull(urlMode, urlHandlerConfig.getDefaultUrlMode());
-    return mode.getLinkUrlPrefix(self, instanceTypeService.getRunModes(), currentPage, targetPage);
+    String configuredUrlPrefix = mode.getLinkUrlPrefix(self, instanceTypeService.getRunModes(), currentPage, targetPage);
+    return UrlPrefix.applyAutoDetection(configuredUrlPrefix, self);
   }
 
   String externalizeResourceUrl(final String url, final Resource targetResource, final UrlMode urlMode) {
@@ -218,7 +219,8 @@ public final class UrlHandlerImpl implements UrlHandler {
   @SuppressWarnings("null")
   private String getResourceUrlPrefix(UrlMode urlMode, Resource targetResource) {
     UrlMode mode = ObjectUtils.defaultIfNull(urlMode, urlHandlerConfig.getDefaultUrlMode());
-    return mode.getResourceUrlPrefix(self, instanceTypeService.getRunModes(), currentPage, targetResource);
+    String configuredUrlPrefix = mode.getResourceUrlPrefix(self, instanceTypeService.getRunModes(), currentPage, targetResource);
+    return UrlPrefix.applyAutoDetection(configuredUrlPrefix, self);
   }
 
   String buildUrl(String path, String selector, String extension, String suffix) { //NOPMD

--- a/src/main/java/io/wcm/handler/url/impl/UrlPrefix.java
+++ b/src/main/java/io/wcm/handler/url/impl/UrlPrefix.java
@@ -1,0 +1,126 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2022 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.handler.url.impl;
+
+import java.util.Enumeration;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.adapter.Adaptable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implements auto-detection for Site URL prefix (author or publish).
+ * This works only if the adaptable is of SlingHttpServletRequest.
+ */
+final class UrlPrefix {
+
+  /**
+   * String that is provided in site URL config to enable auto-detection.
+   */
+  public static final String AUTO_DETECTION = "<auto>";
+
+  static final String HTTP_HEADER_X_FORWARDED_HOST = "X-Forwarded-Host";
+  static final String HTTP_HEADER_X_FORWARDED_PROTO = "X-Forwarded-Proto";
+  static final String HTTP_HEADER_HOST = "Host";
+  static final String HTTP_HEADER_X_FORWARDED_SSL = "X-Forwarded-SSL";
+  static final String VALUE_ON = "on";
+
+  private static final Logger log = LoggerFactory.getLogger(UrlPrefix.class);
+
+  private UrlPrefix() {
+    // static methods only
+  }
+
+  /**
+   * Apply auto-detection to URL prefix.
+   * @param configuredUrlPrefix Configured URL prefix
+   * @param adaptable Adaptable
+   * @return Configured or auto-detected URL prefix
+   */
+  static @Nullable String applyAutoDetection(@Nullable String configuredUrlPrefix, @NotNull Adaptable adaptable) {
+    String urlPrefix = configuredUrlPrefix;
+    if (StringUtils.contains(configuredUrlPrefix, AUTO_DETECTION)) {
+      // remove auto marker (detection might not be possible if adaptable is not a request)
+      urlPrefix = StringUtils.trimToNull(StringUtils.remove(configuredUrlPrefix, AUTO_DETECTION));
+      // auto-detect based on request
+      if (adaptable instanceof SlingHttpServletRequest) {
+        SlingHttpServletRequest request = (SlingHttpServletRequest)adaptable;
+        urlPrefix = detectFromForwardedHeader(request);
+        if (urlPrefix == null) {
+          urlPrefix = detectFromServletRequest(request);
+        }
+      }
+    }
+    return urlPrefix;
+  }
+
+  /**
+   * Try to get URL prefix from X-Forwarded header (e.g. in AEMaaCS environment).
+   * @param request Request
+   * @return Url prefix or null
+   */
+  private static @Nullable String detectFromForwardedHeader(@NotNull SlingHttpServletRequest request) {
+
+    // output request headers to log in TRACE level
+    if (log.isTraceEnabled()) {
+      StringBuilder output = new StringBuilder();
+      Enumeration<String> headers = request.getHeaderNames();
+      while (headers.hasMoreElements()) {
+        String header = headers.nextElement();
+        if (output.length() > 0) {
+          output.append("; ");
+        }
+        output.append(header).append('=').append(request.getHeader(header));
+      }
+      log.trace("HTTP headers: {}", output);
+    }
+
+    // this should work for AEMaaCS author
+    String forwardedHost = request.getHeader(HTTP_HEADER_X_FORWARDED_HOST);
+    String forwardedProto = request.getHeader(HTTP_HEADER_X_FORWARDED_PROTO);
+    if (StringUtils.isNotEmpty(forwardedHost) && StringUtils.isNotEmpty(forwardedProto)) {
+      return forwardedProto + "://" + forwardedHost;
+    }
+
+    // this should work for AEMaaCS publish
+    String host = request.getHeader(HTTP_HEADER_HOST);
+    String forwardedSsl = request.getHeader(HTTP_HEADER_X_FORWARDED_SSL);
+    if (StringUtils.isNotEmpty(host) && StringUtils.equalsIgnoreCase(forwardedSsl, VALUE_ON)) {
+      return "https://" + host;
+    }
+
+    return null;
+  }
+
+  private static @NotNull String detectFromServletRequest(@NotNull SlingHttpServletRequest request) {
+    StringBuilder urlPrefix = new StringBuilder();
+    urlPrefix.append(request.getScheme()).append("://").append(request.getServerName());
+    int port = request.getServerPort();
+    if ((request.isSecure() && port != 443) || (!request.isSecure() && port != 80)) {
+      urlPrefix.append(':').append(Integer.toString(port));
+    }
+    return urlPrefix.toString();
+  }
+
+}

--- a/src/main/java/io/wcm/handler/url/package-info.java
+++ b/src/main/java/io/wcm/handler/url/package-info.java
@@ -20,5 +20,5 @@
 /**
  * URL Handler API.
  */
-@org.osgi.annotation.versioning.Version("1.2")
+@org.osgi.annotation.versioning.Version("1.2.1")
 package io.wcm.handler.url;

--- a/src/site/markdown/usage.md
+++ b/src/site/markdown/usage.md
@@ -31,10 +31,14 @@ With the different Enumeration constants from [UrlModes][url-modes] you have fin
 To make sure that the externalization works properly you have to configure three Parameters in the [Context-Aware Configuration][caconfig] for configuration "wcm.io Handler Site URLs" (internal name: `io.wcm.handler.url.SiteConfig`):
 
 * `siteUrl`: Site URL on public access from outside, for non-secure access (HTTP).
-* `siteUrlSecure`: Site URL for public access from outside, for secure access (HTTPS).
-* `siteUrlAuthor`: Site URL on author instance.
+* `siteUrlSecure`: Site URL for public access from outside, for secure access (HTTPS). If not configured, `siteUrl` is used.
+* `siteUrlAuthor`: Site URL on author instance. If not configured, `siteUrl` is used.
 
 Site URL is a protocol and hostname, e.g. `http://www.mycompany.com`.
+
+Additionally, you can add a placeholder `<auto>` to the site URL string. This enables an auto-detection of the Site URL based on the host name that was used when requesting the AEM instance. This is especially useful for AEMaaCS instances where different host names are used for access from public side, and access during functional tests and UI tests executed from Cloud Manager. It is recommended to specify both placeholder `<auto>` and the actual public URL at the same time - the latter serves as fallback when the auto-detection is not possible. Auto-detection does only work, when the handler is adapted from a `SlingHttpServletRequest` instance.
+
+Example: `<auto>http://www.mycompany.com`
 
 
 ### Site Root detection

--- a/src/test/java/io/wcm/handler/url/impl/UrlPrefixTest.java
+++ b/src/test/java/io/wcm/handler/url/impl/UrlPrefixTest.java
@@ -128,4 +128,35 @@ class UrlPrefixTest {
     assertEquals("https://aemaacs-publish", applyAutoDetection("<auto>", context.request()));
   }
 
+  @Test
+  void testRequestPlaceholder_incomplete1() {
+    context.request().setHeader(HTTP_HEADER_X_FORWARDED_HOST, "aemaacs-author");
+    assertEquals("https://servername:8080", applyAutoDetection("<auto>", context.request()));
+  }
+
+  @Test
+  void testRequestPlaceholder_incomplete2() {
+    context.request().setHeader(HTTP_HEADER_X_FORWARDED_PROTO, "https");
+    assertEquals("https://servername:8080", applyAutoDetection("<auto>", context.request()));
+  }
+
+  @Test
+  void testRequestPlaceholder_incomplete3() {
+    context.request().setHeader(HTTP_HEADER_HOST, "aemaacs-publish");
+    assertEquals("https://servername:8080", applyAutoDetection("<auto>", context.request()));
+  }
+
+  @Test
+  void testRequestPlaceholder_incomplete4() {
+    context.request().setHeader(HTTP_HEADER_X_FORWARDED_SSL, VALUE_ON);
+    assertEquals("https://servername:8080", applyAutoDetection("<auto>", context.request()));
+  }
+
+  @Test
+  void testRequestPlaceholder_incomplete5() {
+    context.request().setHeader(HTTP_HEADER_HOST, "aemaacs-publish");
+    context.request().setHeader(HTTP_HEADER_X_FORWARDED_SSL, "off");
+    assertEquals("https://servername:8080", applyAutoDetection("<auto>", context.request()));
+  }
+
 }

--- a/src/test/java/io/wcm/handler/url/impl/UrlPrefixTest.java
+++ b/src/test/java/io/wcm/handler/url/impl/UrlPrefixTest.java
@@ -96,6 +96,13 @@ class UrlPrefixTest {
   }
 
   @Test
+  void testRequestPlaceholderHttps() {
+    context.request().setServerPort(8443);
+    context.request().setScheme("https");
+    assertEquals("https://servername:8443", applyAutoDetection("<auto>", context.request()));
+  }
+
+  @Test
   void testRequestPlaceholderHttpDefaultPort() {
     context.request().setServerPort(80);
     context.request().setScheme("http");
@@ -131,32 +138,32 @@ class UrlPrefixTest {
   @Test
   void testRequestPlaceholder_incomplete1() {
     context.request().setHeader(HTTP_HEADER_X_FORWARDED_HOST, "aemaacs-author");
-    assertEquals("https://servername:8080", applyAutoDetection("<auto>", context.request()));
+    assertEquals("http://servername:8080", applyAutoDetection("<auto>", context.request()));
   }
 
   @Test
   void testRequestPlaceholder_incomplete2() {
     context.request().setHeader(HTTP_HEADER_X_FORWARDED_PROTO, "https");
-    assertEquals("https://servername:8080", applyAutoDetection("<auto>", context.request()));
+    assertEquals("http://servername:8080", applyAutoDetection("<auto>", context.request()));
   }
 
   @Test
   void testRequestPlaceholder_incomplete3() {
     context.request().setHeader(HTTP_HEADER_HOST, "aemaacs-publish");
-    assertEquals("https://servername:8080", applyAutoDetection("<auto>", context.request()));
+    assertEquals("http://servername:8080", applyAutoDetection("<auto>", context.request()));
   }
 
   @Test
   void testRequestPlaceholder_incomplete4() {
     context.request().setHeader(HTTP_HEADER_X_FORWARDED_SSL, VALUE_ON);
-    assertEquals("https://servername:8080", applyAutoDetection("<auto>", context.request()));
+    assertEquals("http://servername:8080", applyAutoDetection("<auto>", context.request()));
   }
 
   @Test
   void testRequestPlaceholder_incomplete5() {
     context.request().setHeader(HTTP_HEADER_HOST, "aemaacs-publish");
     context.request().setHeader(HTTP_HEADER_X_FORWARDED_SSL, "off");
-    assertEquals("https://servername:8080", applyAutoDetection("<auto>", context.request()));
+    assertEquals("http://servername:8080", applyAutoDetection("<auto>", context.request()));
   }
 
 }

--- a/src/test/java/io/wcm/handler/url/impl/UrlPrefixTest.java
+++ b/src/test/java/io/wcm/handler/url/impl/UrlPrefixTest.java
@@ -1,0 +1,131 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2022 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.handler.url.impl;
+
+import static io.wcm.handler.url.impl.UrlPrefix.HTTP_HEADER_HOST;
+import static io.wcm.handler.url.impl.UrlPrefix.HTTP_HEADER_X_FORWARDED_HOST;
+import static io.wcm.handler.url.impl.UrlPrefix.HTTP_HEADER_X_FORWARDED_PROTO;
+import static io.wcm.handler.url.impl.UrlPrefix.HTTP_HEADER_X_FORWARDED_SSL;
+import static io.wcm.handler.url.impl.UrlPrefix.VALUE_ON;
+import static io.wcm.handler.url.impl.UrlPrefix.applyAutoDetection;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.apache.sling.api.resource.Resource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.wcm.handler.url.testcontext.AppAemContext;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+
+@ExtendWith(AemContextExtension.class)
+class UrlPrefixTest {
+
+  final AemContext context = AppAemContext.newAemContext();
+  private Resource resource;
+
+  @BeforeEach
+  void setUp() {
+    resource = context.currentResource(context.create().resource("/content/test"));
+    context.request().setServerName("servername");
+    context.request().setServerPort(8080);
+  }
+
+  @Test
+  void testResourceNull() {
+    assertNull(applyAutoDetection(null, resource));
+  }
+
+  @Test
+  void testResourceEmpty() {
+    assertEquals("", applyAutoDetection("", resource));
+  }
+
+  @Test
+  void testResourceUrl() {
+    assertEquals("https://myhost", applyAutoDetection("https://myhost", resource));
+  }
+
+  @Test
+  void testResourcePlaceholder() {
+    assertNull(applyAutoDetection("<auto>", resource));
+  }
+
+  @Test
+  void testResourceUrlPlaceholder() {
+    assertEquals("https://myhost", applyAutoDetection("<auto>https://myhost", resource));
+  }
+
+  @Test
+  void testRequestNull() {
+    assertNull(applyAutoDetection(null, context.request()));
+  }
+
+  @Test
+  void testRequestEmpty() {
+    assertEquals("", applyAutoDetection("", context.request()));
+  }
+
+  @Test
+  void testRequestUrl() {
+    assertEquals("https://myhost", applyAutoDetection("https://myhost", context.request()));
+  }
+
+  @Test
+  void testRequestPlaceholder() {
+    assertEquals("http://servername:8080", applyAutoDetection("<auto>", context.request()));
+  }
+
+  @Test
+  void testRequestPlaceholderHttpDefaultPort() {
+    context.request().setServerPort(80);
+    context.request().setScheme("http");
+    assertEquals("http://servername", applyAutoDetection("<auto>", context.request()));
+  }
+
+  @Test
+  void testRequestPlaceholderHttpsDefaultPort() {
+    context.request().setServerPort(443);
+    context.request().setScheme("https");
+    assertEquals("https://servername", applyAutoDetection("<auto>", context.request()));
+  }
+
+  @Test
+  void testRequestUrlPlaceholder() {
+    assertEquals("http://servername:8080", applyAutoDetection("<auto>https://myhost", context.request()));
+  }
+
+  @Test
+  void testRequestPlaceholder_AEMaaCS_author() {
+    context.request().setHeader(HTTP_HEADER_X_FORWARDED_HOST, "aemaacs-author");
+    context.request().setHeader(HTTP_HEADER_X_FORWARDED_PROTO, "https");
+    assertEquals("https://aemaacs-author", applyAutoDetection("<auto>", context.request()));
+  }
+
+  @Test
+  void testRequestPlaceholder_AEMaaCS_publish() {
+    context.request().setHeader(HTTP_HEADER_HOST, "aemaacs-publish");
+    context.request().setHeader(HTTP_HEADER_X_FORWARDED_SSL, VALUE_ON);
+    assertEquals("https://aemaacs-publish", applyAutoDetection("<auto>", context.request()));
+  }
+
+}


### PR DESCRIPTION
Placeholder <auto> can be used in the author/publish URL properties in Site Config to enable auto-detection of these URLs based on the requested URL.

The placeholder can be combined with a fallback URL - if auto-detection is not possible (because the link is build outside request context) the configured URL is used.