### PR TITLE
Add UrlBuilder.disableSuffixSelector to allow to diable the automaticaddition of a "suffix" selector in case a suffix is present.

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,6 +23,13 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.10.0" date="not released">
+      <action type="add" dev="sseifert">
+        Add UrlBuilder.disableSuffixSelector to allow to diable the automatic addition of a "suffix" selector in case a suffix is present.
+        Although recommended as best practice, this can be omitted if you are sure your URLs are always either include a suffix or never do, so there is no risk for file name clashes in dispatcher cache.
+      </action>
+    </release>
+
     <release version="1.9.0" date="2022-09-02">
       <action type="add" dev="sseifert"><![CDATA[
         Add UrlHandler.applySiteUrlAutoDetection method which allows to apply the Site URL auto-detection via <code>&lt;auto&gt;</code> placeholder also

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
   <groupId>io.wcm</groupId>
   <artifactId>io.wcm.handler.url</artifactId>
-  <version>1.9.1-SNAPSHOT</version>
+  <version>1.10.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>URL Handler</name>

--- a/src/main/java/io/wcm/handler/url/UrlBuilder.java
+++ b/src/main/java/io/wcm/handler/url/UrlBuilder.java
@@ -92,6 +92,17 @@ public interface UrlBuilder {
   UrlBuilder urlMode(UrlMode urlMode);
 
   /**
+   * Disable the automatic addition of an additional selector {@link UrlHandler#SELECTOR_SUFFIX}
+   * in case a suffix is present for building the URL. Although recommended as best practice, this can
+   * be omitted if you are sure your URLs are always either include a suffix or never do, so there is no risk
+   * for file name clashes in dispatcher cache.
+   * @param disableSuffixSelector If set to true, no additional suffix selector is added
+   * @return URL builder
+   */
+  @NotNull
+  UrlBuilder disableSuffixSelector(boolean disableSuffixSelector);
+
+  /**
    * Build URL
    * @return URL
    */

--- a/src/main/java/io/wcm/handler/url/impl/UrlBuilderImpl.java
+++ b/src/main/java/io/wcm/handler/url/impl/UrlBuilderImpl.java
@@ -48,6 +48,7 @@ final class UrlBuilderImpl implements UrlBuilder {
   private Set<String> inheritableParameterNames;
   private String fragment;
   private UrlMode urlMode;
+  private boolean disableSuffixSelector;
 
   /**
    * @param path Path for URL (without any hostname, scheme, extension, suffix etc.)
@@ -126,9 +127,16 @@ final class UrlBuilderImpl implements UrlBuilder {
     return this;
   }
 
+
+  @Override
+  public @NotNull UrlBuilder disableSuffixSelector(boolean value) {
+    this.disableSuffixSelector = value;
+    return this;
+  }
+
   @Override
   public String build() {
-    String url = urlHandler.buildUrl(path, selectors, extension, suffix);
+    String url = urlHandler.buildUrl(path, selectors, extension, suffix, disableSuffixSelector);
     if (StringUtils.isNotEmpty(queryString) || inheritableParameterNames != null) {
       url = urlHandler.appendQueryString(url, queryString, inheritableParameterNames);
     }

--- a/src/main/java/io/wcm/handler/url/impl/UrlHandlerImpl.java
+++ b/src/main/java/io/wcm/handler/url/impl/UrlHandlerImpl.java
@@ -224,7 +224,7 @@ public final class UrlHandlerImpl implements UrlHandler {
     return UrlPrefix.applyAutoDetection(configuredUrlPrefix, self);
   }
 
-  String buildUrl(String path, String selector, String extension, String suffix) { //NOPMD
+  String buildUrl(String path, String selector, String extension, String suffix, boolean disableSuffixSelector) { //NOPMD
     if (StringUtils.isBlank(path)) {
       return null;
     }
@@ -260,7 +260,9 @@ public final class UrlHandlerImpl implements UrlHandler {
       }
 
       // add a ".suffix" selector to avoid overlapping of filenames between suffixed and non-suffixed versions of the same page in the dispatcher cache
-      selectorPart.append('.').append(UrlHandler.SELECTOR_SUFFIX);
+      if (!disableSuffixSelector) {
+        selectorPart.append('.').append(UrlHandler.SELECTOR_SUFFIX);
+      }
     }
 
     // build externalized url

--- a/src/main/java/io/wcm/handler/url/package-info.java
+++ b/src/main/java/io/wcm/handler/url/package-info.java
@@ -20,5 +20,5 @@
 /**
  * URL Handler API.
  */
-@org.osgi.annotation.versioning.Version("1.3.0")
+@org.osgi.annotation.versioning.Version("1.4.0")
 package io.wcm.handler.url;

--- a/src/test/java/io/wcm/handler/url/impl/UrlHandlerImplTest.java
+++ b/src/test/java/io/wcm/handler/url/impl/UrlHandlerImplTest.java
@@ -604,6 +604,18 @@ class UrlHandlerImplTest {
   }
 
   @Test
+  void testBuildUrl_disableSuffixSelector() {
+    UrlHandler urlHandler = AdaptTo.notNull(adaptable(), UrlHandler.class);
+
+    assertEquals("/the/path.ext/suffix1.ext",
+        urlHandler.get("/the/path").extension("ext").suffix("suffix1").disableSuffixSelector(true).build());
+    assertEquals("/the/path.selector.ext/suffix1.ext",
+        urlHandler.get("/the/path").selectors("selector").extension("ext").suffix("suffix1").disableSuffixSelector(true).build());
+    assertEquals("/the/path.selector.ext/suffix2.myext",
+        urlHandler.get("/the/path").selectors("selector").extension("ext").suffix("/suffix2.myext").disableSuffixSelector(true).build());
+  }
+
+  @Test
   void testUrlWithSpaces() {
     UrlHandler urlHandler = AdaptTo.notNull(adaptable(), UrlHandler.class);
 


### PR DESCRIPTION
Although recommended as best practice, this can be omitted if you are sure your URLs are always either include a suffix or never do, so there is no risk for file name clashes in dispatcher cache.