### PR TITLE
global.jsp: Get rid of deprecated Granite XSS API

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -25,7 +25,7 @@
   <body>
 
     <release version="2.1.1" date="not released">
-      <action type="update" dev="sseifert">
+      <action type="update" dev="sseifert" issue="18">
         global.jsp: Get rid of deprecated Granite XSS API.
       </action>
     </release>

--- a/changes.xml
+++ b/changes.xml
@@ -24,6 +24,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/2.0.0 https://maven.apache.org/xsd/changes-2.0.0.xsd">
   <body>
 
+    <release version="2.1.1" date="not released">
+      <action type="update" dev="sseifert">
+        global.jsp: Get rid of deprecated Granite XSS API.
+      </action>
+    </release>
+
     <release version="2.1.0" date="2024-03-21">
       <action type="add" dev="royteeuwen" issue="10">
         Add optional support for using vanity paths when building URLs to AEM pages.

--- a/src/main/webapp/app-root/components/granite/global/global.jsp
+++ b/src/main/webapp/app-root/components/granite/global/global.jsp
@@ -17,8 +17,7 @@
   limitations under the License.
   #L%
   --%>
-<%@page import="com.adobe.granite.xss.XSSAPI"%><%
-%><%@page import="com.day.cq.i18n.I18n"%><%
+<%@page import="com.day.cq.i18n.I18n"%><%
 %><%@page import="com.adobe.granite.ui.components.ComponentHelper"%><%
 %><%@page session="false" pageEncoding="UTF-8" contentType="text/html" %><%
 %><%@taglib prefix="sling" uri="http://sling.apache.org/taglibs/sling/1.2" %><%
@@ -27,15 +26,5 @@
 
 final ComponentHelper cmp = new ComponentHelper(pageContext);
 final I18n i18n = cmp.getI18n();
-final XSSAPI xssAPI = cmp.getXss();
-
-%><%!
-String outVar(XSSAPI xssAPI, I18n i18n, String text) {
-  return xssAPI.encodeForHTML(i18n.getVar(text));
-}
-
-String outAttrVar(XSSAPI xssAPI, I18n i18n, String text) {
-  return xssAPI.encodeForHTMLAttr(i18n.getVar(text));
-}
 
 %>


### PR DESCRIPTION
it was never used in the actual Granite UI components